### PR TITLE
Removed deprecated skeletonize_3d

### DIFF
--- a/cldice_metric/cldice.py
+++ b/cldice_metric/cldice.py
@@ -1,4 +1,4 @@
-from skimage.morphology import skeletonize, skeletonize_3d
+from skimage.morphology import skeletonize
 import numpy as np
 
 def cl_score(v, s):
@@ -24,10 +24,11 @@ def clDice(v_p, v_l):
     Returns:
         [float]: [cldice metric]
     """
-    if len(v_p.shape)==2:
+    if v_p.ndim in (2, 3):
         tprec = cl_score(v_p,skeletonize(v_l))
         tsens = cl_score(v_l,skeletonize(v_p))
-    elif len(v_p.shape)==3:
-        tprec = cl_score(v_p,skeletonize_3d(v_l))
-        tsens = cl_score(v_l,skeletonize_3d(v_p))
-    return 2*tprec*tsens/(tprec+tsens)
+        return 2*tprec*tsens/(tprec+tsens)
+    else:
+        raise ValueError(
+            f"Predicted image must be 2D or 3D, but got array with {v_p.ndim} dimensions"
+        )


### PR DESCRIPTION
hey @jocpae  @suprosanna  i updated the clDice metric to stop using `skeletonize_3d`, because it's now deprecated in `scikit-image`. The `skeletonize` function now handles both 2D and 3D cases as indicated in the [documentation](https://github.com/scikit-image/scikit-image/blob/v0.25.2/skimage/morphology/_skeletonize.py#L18-L96). The code now uses `skeletonize` for both 2D and 3D inputs. I also included a dimensionality check with a proper error message. The functionality remains the same, but the implementation is more up to date.
Would love to know your feedback on this update and if anything needs to be modified in the code. Thanks :D